### PR TITLE
Improvements to ai_salience

### DIFF
--- a/R/ai_salience.R
+++ b/R/ai_salience.R
@@ -24,22 +24,42 @@
 #' }
 #' @export
 ai_salience <- function(.data, topics, chat_fn, ..., verbose = TRUE) {
-  
+
   # Predefine the type_object for salience classification
   predefined_type_object <- type_array(
     "Array of classification results. The scores should sum to 1.",
     type_object(
       topic = type_enum("The category name", values = paste(topics)),
-      score = type_number("The classification score for the category, ranging from 0.0 to 1.0")
+      score = type_number("The salience score for the category, ranging from 0.0 to 1.0")
     )
   )
-  
+
   # Call ai_text with pre-set type_object and flexible arguments
-  ai_text(
+  result <- ai_text(
     .data = .data,
     chat_fn = chat_fn,
     type_object = predefined_type_object,
     verbose = verbose,
     ...
   )
+
+  # Remove topic columns
+  topic_cols <- grep("^topic", names(result), value = TRUE)
+  result <- result[, !names(result) %in% topic_cols]
+
+  # Rename score columns to salience_[topic]
+  score_cols <- grep("^score", names(result), value = TRUE)
+  new_names <- paste0("salience_", topics)
+
+  # Rename the columns (assuming they're in the same order as topics)
+  for (i in seq_along(score_cols)) {
+    names(result)[names(result) == score_cols[i]] <- new_names[i]
+  }
+
+  # make salience values numeric
+  for (col in paste0("salience_", topics)) {
+    result[[col]] <- as.numeric(result[[col]])
+  }
+
+  return(result)
 }

--- a/tests/testthat/test-ai_salience.R
+++ b/tests/testthat/test-ai_salience.R
@@ -1,4 +1,4 @@
-make_mock_chat_fn <- function(return_scores = c("0.95", "0.8")) {
+make_mock_chat_fn <- function(return_scores = c(0.95, 0.8)) {
   i <- 0
   function(...) {
     structure(list(
@@ -12,13 +12,13 @@ make_mock_chat_fn <- function(return_scores = c("0.95", "0.8")) {
 }
 
 test_that("ai_salience returns expected output for one document", {
-  chat_fn <- make_mock_chat_fn(c("0.95"))
+  chat_fn <- make_mock_chat_fn(c(0.95))
   result <- ai_salience("Test document", topics = c("TopicA"), chat_fn = chat_fn, verbose = FALSE)
 
   expect_s3_class(result, "data.frame")
-  expect_true("score" %in% colnames(result))
-  expect_type(result$score, "character")
-  expect_equal(result$score, "0.95")
+  expect_true("salience_TopicA" %in% colnames(result))
+  expect_true(is.numeric(result$salience_TopicA))
+  expect_equal(result$salience_TopicA, 0.95)
 })
 
 test_that("ai_salience works with multiple documents", {
@@ -27,8 +27,8 @@ test_that("ai_salience works with multiple documents", {
   result <- ai_salience(docs, topics = c("TopicA"), chat_fn = chat_fn, verbose = FALSE)
 
   expect_s3_class(result, "data.frame")
-  expect_true(all(c("score", "topic") %in% colnames(result)))
+  expect_true(all(c("id", "salience_TopicA") %in% colnames(result)))
   expect_equal(nrow(result), length(docs))
-  expect_type(result$score, "character")
-  expect_equal(result$score, c("0.95", "0.8"))
+  expect_type(result$salience_TopicA, "double")
+  expect_equal(result$salience_TopicA, c(0.95, 0.8))
 })


### PR DESCRIPTION
- fixes column names to match issues
- guarantees a numeric result

But this wrapper remains very limited and I would not think of using it in its current form.

* It does not explain what is salience or how it should be scored, or how to use the scale
* It does not provide any definition of the issues, beyond a label from type_array
* It does not provide for any scale boundaries to be applied - it's fixed only at 0 to 1.0